### PR TITLE
Fix typo: HAVEL_LEVEL2

### DIFF
--- a/acl.c
+++ b/acl.c
@@ -120,7 +120,7 @@ static PyObject* ACL_new(PyTypeObject* type, PyObject* args,
         Py_DECREF(newacl);
         return NULL;
     }
-#ifdef HAVEL_LEVEL2
+#ifdef HAVE_LEVEL2
     acl->entry_id = ACL_FIRST_ENTRY;
 #endif
 


### PR DESCRIPTION
This change initializes the `entry_id` to `ACL_FIRST_ENTRY` when `ACL`
objects are created.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>